### PR TITLE
リファクタリング: 数が多いパラメータを構造体に変更。

### DIFF
--- a/VirtualStorageLibrary.Test/VirtualStorageTests.cs
+++ b/VirtualStorageLibrary.Test/VirtualStorageTests.cs
@@ -3922,7 +3922,7 @@ namespace AkiraNet.VirtualStorageLibrary.Test
         [TestMethod]
         public void ResolveDeepDirectoryStructureTest()
         {
-            const int Depth = 1000; // 例として10階層の深さを設定
+            const int Depth = 500;
             const string BaseDir = "/dir1";
             var vs = new VirtualStorage();
 


### PR DESCRIPTION
WalkPathToTargetInternalのパラメータを構造体に変更した。
また、テストResolveDeepDirectoryStructureTestのDepthを1000から500に変更した。1000だとスタックオーバーフローが発生する為。